### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CC-EXT-SDK/README.md
+++ b/CC-EXT-SDK/README.md
@@ -1,4 +1,4 @@
-#Creative Cloud Extension SDK
+# Creative Cloud Extension SDK
 
 (THIS IS THE CEP5 BRANCH)
 
@@ -7,7 +7,7 @@ As of now, it consists of some command line tool / scripts and some templates.
 
 
  
-###createext 
+### createext 
 
 Creates an extension panel from a given template and deploys it.
 
@@ -28,7 +28,7 @@ Example: `createext.sh default com.example.ext`  ... will create the extension *
 You can of course add your own templates to the `templates` folder.
 
 
-###deployext
+### deployext
 
 Copies an existing extension folder to the appropriate location for it to be executed.
 
@@ -52,12 +52,12 @@ Example: To deploy an extension located at `~/my-awesome-ext/` with the ID `com.
 For a sample extension to start with, check out my [Creative Cloud Extension boilerplate](https://github.com/davidderaedt/ccext-boilerplate).
 
 
-###setdebugmode and disabledebugmode
+### setdebugmode and disabledebugmode
 
 For extensions to run, you should first run `setdebugmode.sh` (mac) or `setdebugmode.bat` (win) once to properly configure your system for extension development. Otherwise, extensions will refuse to launch.
 `disabledebugmode.sh` reverts to the default behavior. Windows users should update the CEP registry key manually.
 
-###execextendscript
+### execextendscript
 
 This shell script can be used to execute an ExtendScript file in Photoshop, Illustrator, or InDesign on a mac via command line. Unfortunately, there is no windows equivalent for now.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#[Creative Cloud Extension Builder for Brackets](http://davidderaedt.github.io/CC-Extension-Builder-for-Brackets/)
+# [Creative Cloud Extension Builder for Brackets](http://davidderaedt.github.io/CC-Extension-Builder-for-Brackets/)
 
 
 ![screenshot](http://www.dehats.com/resources/ccextbrackets/header.jpg "screenshot")
@@ -8,7 +8,7 @@ A [Brackets](http://brackets.io/) extension to let you create HTML based extensi
 For more informations, go to: [Creative Cloud Extension Builder for Brackets](http://davidderaedt.github.io/CC-Extension-Builder-for-Brackets/)
 
 
-##Installation
+## Installation
 
 You don't need to download anything. Just do the following:
 
@@ -17,7 +17,7 @@ You don't need to download anything. Just do the following:
 
 No need to relaunch the app, your extension is ready to use.
 
-##Contributions
+## Contributions
 
 Contributions are welcome, but be sure what you want to contribute to.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
